### PR TITLE
Single code base for python 2 and 3, without using 2to3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+#########################################
+# Editor temporary/working/backup files #
+.#*
+[#]*#
+*~
+*$
+*.bak
+*.kdev4
+.project
+.pydevproject
+
+# Compiled source #
+###################
+*.a
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.py[ocd]
+*.so
+
+# Python files #
+################
+# setup.py working directory
+build
+# sphinx build directory
+doc/_build
+# setup.py dist directory
+dist
+# Egg metadata
+*.egg-info
+# tox testing tool
+.tox
+
+# OS generated files #
+######################
+.directory
+.gdb_history
+.DS_Store?
+ehthumbs.db
+Icon?
+Thumbs.db
+
+# Things specific to this project #
+###################################
+
+# Documentation generated files #
+#################################

--- a/gsw/gibbs/conversions.py
+++ b/gsw/gibbs/conversions.py
@@ -74,11 +74,11 @@ def check_input(SP, p, lon, lat):
     # needed, it should not just be for the "from_SP" functions.
     if False:
         if ((p < -1.5) | (p > 12000)).any():
-            raise(Exception, 'Sstar_from_SP: pressure is out of range')
+            raise Exception('Sstar_from_SP: pressure is out of range')
         if ((lon < 0) | (lon > 360)).any():
-            raise(Exception, 'Sstar_from_SP: longitude is out of range')
+            raise Exception('Sstar_from_SP: longitude is out of range')
         if (np.abs(lat) > 90).any():
-            raise(Exception, 'Sstar_from_SP: latitude is out of range')
+            raise Exception('Sstar_from_SP: latitude is out of range')
 
     SP = np.maximum(SP, 0)  # Works on masked array also.
 

--- a/gsw/gibbs/library.py
+++ b/gsw/gibbs/library.py
@@ -143,7 +143,7 @@ class SA_table(object):
         p, lon, lat = np.broadcast_arrays(p, lon, lat)
         if p.ndim > 1:
             shape_in = p.shape
-            p, lon, lat = map(np.ravel, (p, lon, lat))
+            p, lon, lat = list(map(np.ravel, (p, lon, lat)))
             reshaped = True
         else:
             reshaped = False
@@ -432,7 +432,7 @@ def SA_from_SP_Baltic(SP, lon, lat):
         input_mask = input_mask | lon.mask
     if np.ma.is_masked(lat):
         input_mask = input_mask | lat.mask
-    SP, lon, lat = map(np.atleast_1d, (SP, lon, lat))
+    SP, lon, lat = list(map(np.atleast_1d, (SP, lon, lat)))
     SP, lon, lat = np.broadcast_arrays(SP, lon, lat)
     inds_baltic = in_Baltic(lon, lat)
     #SA_baltic = np.ma.masked_all(SP.shape, dtype=np.float)
@@ -488,7 +488,7 @@ def SP_from_SA_Baltic(SA, lon, lat):
     Modifications:
     2010-07-23. David Jackett, Trevor McDougall & Paul Barker
     """
-    SA, lon, lat = map(np.ma.masked_invalid, (SA, lon, lat))
+    SA, lon, lat = list(map(np.ma.masked_invalid, (SA, lon, lat)))
     lon, lat, SA = np.broadcast_arrays(lon, lat, SA)
     inds_baltic = in_Baltic(lon, lat)
     if not inds_baltic.sum():
@@ -543,7 +543,7 @@ def SP_from_SA_Baltic_old(SA, lon, lat):
     Modifications:
     2010-07-23. David Jackett, Trevor McDougall & Paul Barker
     """
-    SA, lon, lat = map(np.ma.masked_invalid, (SA, lon, lat))
+    SA, lon, lat = list(map(np.ma.masked_invalid, (SA, lon, lat)))
     lon, lat, SA = np.broadcast_arrays(lon, lat, SA)
     xb1, xb2, xb3 = 12.6, 7., 26.
     xb1a, xb3a = 45., 26.

--- a/gsw/gibbs/practical_salinity.py
+++ b/gsw/gibbs/practical_salinity.py
@@ -51,7 +51,8 @@ u = (5.180529787390576e-3, 1.052097167201052e-3, 3.666193708310848e-5,
      6.797409608973845e-7, 3.345074990451475e-10, 8.285687652694768e-13)
 k = 0.0162
 
-a, b, c, d, e, P, q, r, u, k = map(np.asarray, (a, b, c, d, e, P, q, r, u, k))
+a, b, c, d, e, P, q, r, u, k = (np.asarray(x)
+                                for x in (a, b, c, d, e, P, q, r, u, k))
 
 
 def C_from_SP(SP, t, p):

--- a/gsw/test/check_functions.py
+++ b/gsw/test/check_functions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import logging
@@ -161,17 +162,17 @@ for exc in etypes:
              isinstance(f.exception, exc)]
     ex_dict[exc] = elist
 
-print "\n%s tests were translated from gsw_check_functions.m" % len(checks)
-print "\n%s tests ran with no error and with correct output" % len(passes)
-print "\n%s tests had an output mismatch:" % len(failures)
-print " ", "\n  ".join(failures)
+print("\n%s tests were translated from gsw_check_functions.m" % len(checks))
+print("\n%s tests ran with no error and with correct output" % len(passes))
+print("\n%s tests had an output mismatch:" % len(failures))
+print(" ", "\n  ".join(failures))
 
-print "\n%s exceptions were raised as follows:" % len(run_problems)
+print("\n%s exceptions were raised as follows:" % len(run_problems))
 for exc in etypes:
-    print "  ", exc.__name__
+    print("  ", exc.__name__)
     strings = ["     %s : %s" % e for e in ex_dict[exc]]
-    print "\n".join(strings)
-    print ""
+    print("\n".join(strings))
+    print("")
 
 checkbunch = Bunch([(c.name, c) for c in checks])
 

--- a/gsw/test/signatures.py
+++ b/gsw/test/signatures.py
@@ -161,8 +161,8 @@ def funclist_by_arg(partslist):
 
 def help_chunk(helptuple, sect):
     lines, secdict = helptuple
-    sections = secdict.keys()
-    ind = secdict.values()
+    sections = list(secdict.keys())
+    ind = list(secdict.values())
     try:
         i0 = sections.index(sect)
     except ValueError:

--- a/gsw/test/test_octave.py
+++ b/gsw/test/test_octave.py
@@ -17,6 +17,8 @@
 # Matlab version is released.
 #
 
+from __future__ import print_function
+
 import os
 import sys
 from collections import OrderedDict

--- a/gsw/test/test_profiles.py
+++ b/gsw/test/test_profiles.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """Unit check for standard profiles for the Gibbs Sea Water python package."""
+from __future__ import print_function
 
 # Auto generates and perform a set of test methods like:
 #

--- a/gsw/test/test_tuples.py
+++ b/gsw/test/test_tuples.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
-"""Unit check for standard profiles for the Gibbs Sea Water python package."""
+"""
+Unit check for standard profiles for the Gibbs Sea Water python package.
+"""
+
+from __future__ import print_function
 
 import os
 import sys
 import unittest
-import functools  # Requires python 2.5.
+import functools
 import numpy as np
 
 import gsw
@@ -58,7 +62,7 @@ def generic_test(self, func=None, argnames=None):
     maxdiff = np.nanmax(abs(out - getattr(cv, func)))
     try:
         self.assertTrue(maxdiff < getattr(cv, func + '_ca'))
-    except AssertionError, e:
+    except AssertionError as e:
         raise AssertionError("Error in %s %s" % (func, e.args))
 
 
@@ -95,5 +99,5 @@ gsw_cf.ICT_first_deriv = np.where(np.abs(gsw_cv.CT_SA - gsw_cf.CT_SA) >=
                                   (gsw_cv.CT_pt - gsw_cf.CT_pt) >=
                                   gsw_cv.CT_pt_ca)
 if gsw_cf.ICT_first_deriv:
-    print(2, 'gsw_CT_first_derivatives:   Failed\n')
+    print((2, 'gsw_CT_first_derivatives:   Failed\n'))
     gsw_cf.gsw_chks = 0

--- a/gsw/utilities/list_npz.py
+++ b/gsw/utilities/list_npz.py
@@ -4,6 +4,7 @@ List to stdout the contents of an npz file used in testing.
 
 The filename is the sole command-line argument.
 """
+from __future__ import print_function
 
 import sys
 import numpy as np
@@ -11,7 +12,7 @@ import numpy as np
 fname = sys.argv[1]
 
 dat = np.load(fname)
-keys = dat.keys()
+keys = list(dat.keys())
 keys.sort()
 klens = [len(str(k)) for k in keys]
 klen = max(klens)
@@ -21,6 +22,6 @@ str_fmt = "{0!s:<{klen}} : {1!s:>10}  {2!s:>12}\n"
 slist = [str_fmt.format(k, dat[k].dtype, dat[k].shape, klen=klen)
          for k in keys]
 
-print ''.join(slist)
+print(''.join(slist))
 
 

--- a/gsw/utilities/mat2npz.py
+++ b/gsw/utilities/mat2npz.py
@@ -13,6 +13,7 @@
 # obs:
 #
 
+from __future__ import print_function
 import numpy as np
 
 from gsw.utilities import loadmatbunch

--- a/gsw/utilities/utilities.py
+++ b/gsw/utilities/utilities.py
@@ -193,7 +193,7 @@ def repair_npzfile_with_objects(infile, outfile):
     """
     dat = np.load(infile)
     out = dict()
-    for k, v in dat.iteritems():
+    for k, v in dat.items():
         if v.dtype.kind == 'O':
             v = v.item()
         out[k] = v
@@ -352,7 +352,7 @@ def _showmatbunch(b, elements=None, origin=None):
         if isinstance(v, Bunch):
             _showmatbunch(v, elements, _origin)
         else:
-            if isinstance(v, (str, str)):
+            if isinstance(v, str):
                 slen = len(v)
                 if slen < 50:
                     entry = v
@@ -378,7 +378,7 @@ def showmatbunch(b):
 
     Returns a multi-line string suitable for printing.
     """
-    if isinstance(b, (str, str)):
+    if isinstance(b, str):
         b = loadmatbunch(b)
     elist = _showmatbunch(b)
     names = [n for n, v in elist]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
@@ -41,7 +40,7 @@ config = dict(name='gsw',
               packages=['gsw', 'gsw/gibbs', 'gsw/utilities', 'gsw/test'],
               package_data={'gsw': ['utilities/data/*.npz']},
               test_suite='tests',
-              use_2to3=True,
+              use_2to3=False,
               license=LICENSE,
               long_description=long_description,
               classifiers=['Development Status :: 4 - Beta',


### PR DESCRIPTION
This is a minimal version, adding no dependency on six or
future modules.

It passes the basic tests, but 'pip install -e .' works only
on python 2.  A normal installation works on python 3.

I also added a .gitignore file taken from matplotlib and
lightly edited.
