### PR TITLE
Removing dependency on scipy to install.

### DIFF
--- a/gsw/utilities/utilities.py
+++ b/gsw/utilities/utilities.py
@@ -6,7 +6,10 @@ import os
 from functools import wraps
 
 import numpy as np
-from scipy.io import loadmat
+try:
+    from scipy.io import loadmat
+except:
+    pass
 
 __all__ = ['Bunch',
            'Cache_npz',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ config = dict(name='gsw',
               download_url='https://pypi.python.org/pypi/gsw/',
               platforms='any',
               keywords=['oceanography', 'seawater', 'TEOS-10', 'gibbs'],
-              install_requires=['numpy', 'scipy'],
+              install_requires=['numpy'],
               extras_require=dict(testing=['pytest'])
               )
 


### PR DESCRIPTION
In a fast glance, looks like the only use for scipy is due loadmat on utilities. Despite Scipy is a common package, wouldn't be better to keep it off the requirements to install gsw?

Here is my suggestion. Scipy is still required for some optionals at utilities, but the main package can be installed and used without it.