### PR TITLE
add publish to allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
     env: TEST_TARGET=default NUMPY=1.12
   - python: 3.6
     env: TEST_TARGET=publish NUMPY=1.12
+  allow_failures:
+  - python: 3.6
+    env: TEST_TARGET=publish NUMPY=1.12
 
 before_install:
     - wget http://bit.ly/miniconda -O miniconda.sh


### PR DESCRIPTION
Since we don't have the rights to publish this at least won't give people the impression that the tests are failing when only publish is failing.

We can revert this once https://github.com/TEOS-10/python-gsw/issues/36 is fixed.